### PR TITLE
Add error code sensors with decoded descriptions

### DIFF
--- a/custom_components/navien_water_heater/const.py
+++ b/custom_components/navien_water_heater/const.py
@@ -1,3 +1,69 @@
 """Constants for Navien Water Heater integration."""
 
 DOMAIN = "navien_water_heater"
+
+# Source: Navien NPE Service Manual, section 5.1 "Error Code List" (v2.21)
+ERROR_CODE_DESCRIPTIONS = {
+    3: {0: "Ignition failure"},
+    4: {0: "False flame detection"},
+    12: {0: "Flame loss"},
+    16: {0: "Overheating of heat exchanger"},
+    30: {0: "Exhaust overheat: flue temperature exceeded 230°F (110°C) for more than 10 seconds"},
+    47: {1: "Abnormal exhaust thermistor (open)", 2: "Abnormal exhaust thermistor (short)"},
+    60: {
+        1: "Abnormal Dual Venturi limit switch operation (ON)",
+        2: "Abnormal Dual Venturi limit switch operation (Close OFF)",
+        3: "Abnormal Dual Venturi limit switch operation (Open ON)",
+    },
+    109: {0: "Abnormal fan motor activity"},
+    110: {
+        1: "Exhaust blockage (checking the fan)",
+        2: "Exhaust blockage (using hot water)",
+        3: "Exhaust blockage (using space heating)",
+    },
+    407: {1: "Abnormal hot water outlet thermistor (open)", 2: "Abnormal hot water outlet thermistor (short)"},
+    421: {1: "Abnormal cold water inlet thermistor (open)", 2: "Abnormal cold water inlet thermistor (short)"},
+    432: {1: "Abnormal cold water inlet 2 thermistor (open)", 2: "Abnormal cold water inlet 2 thermistor (short)"},
+    434: {1: "Abnormal water adjustment valve (open)", 2: "Abnormal water adjustment valve (close)"},
+    438: {0: 'Abnormal circulation pump ("A" models only)'},
+    439: {0: "Abnormal flow sensor"},
+    441: {1: "Abnormal hot water inlet 2 thermistor (open)", 2: "Abnormal hot water inlet 2 thermistor (short)"},
+    445: {1: "Abnormal mixing valve (open)", 2: "Abnormal mixing valve (close)"},
+    515: {
+        **{i: "Abnormal communication between PCB and igniter" for i in range(1, 9)},
+        9: "Abnormal communication between PCB and fan",
+        10: "Abnormal monitoring device of PCB",
+        **{i: "Abnormal communication between PCB and Dual Venturi" for i in (11, 12)},
+    },
+    517: {0: "Abnormal dip switch setting"},
+    593: {1: "Abnormal panel key"},
+    594: {
+        0: "Abnormal input data from high limit switch of heat exchanger",
+        1: "Abnormal input data from exhaust sensor",
+        2: "Abnormal input data from flame rod",
+        **{i: "Abnormal memory of PCB" for i in range(3, 15)},
+        15: "Below the range of input data from pressure sensor",
+        16: "Over the range of input data from pressure sensor",
+    },
+    615: {
+        0: "Abnormal input data from high limit switch of heat exchanger",
+        1: "Abnormal input data from exhaust sensor",
+        2: "Abnormal input data from flame rod",
+        **{i: "Abnormal memory of PCB" for i in range(3, 15)},
+        15: "Below the range of input data from pressure sensor",
+        16: "Over the range of input data from pressure sensor",
+    },
+    736: {0: "Abnormal cascade communication"},
+    740: {
+        1: "Abnormal outdoor temperature sensor (open, outdoor reset curve enabled)",
+        2: "Abnormal outdoor temperature sensor (short, outdoor reset curve enabled)",
+    },
+    760: {0: "Flushing/service alarm"},
+    782: {0: "Abnormal Main-Panel communication"},
+    785: {0: "Abnormal flow switch operation"},
+}
+
+
+def get_error_description(error_code, sub_error_code):
+    """Look up the human-readable description for an error/sub-error code pair."""
+    return ERROR_CODE_DESCRIPTIONS.get(error_code, {}).get(sub_error_code)

--- a/custom_components/navien_water_heater/sensor.py
+++ b/custom_components/navien_water_heater/sensor.py
@@ -18,10 +18,10 @@ FLOW_GALLONS_PER_MIN = 'gal/min'
 FLOW_LITERS_PER_MIN = 'liters/min'
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from .const import DOMAIN
+from .const import DOMAIN, get_error_description
 from asyncio import sleep
 import logging
 _LOGGER=logging.getLogger(__name__)
@@ -55,6 +55,18 @@ class TempSensorDescription():
         else:
             return temp
 
+class RawSensorDescription():
+    """Class for values that need no conversion"""
+    def __init__(self, state_class, native_unit_of_measurement, name, device_class=None, entity_category=None) -> None:
+        self.state_class = state_class
+        self.native_unit_of_measurement = native_unit_of_measurement
+        self.name = name
+        self.device_class = device_class
+        self.entity_category = entity_category
+
+    def convert(self,val):
+        return val
+
 def get_description(hass_units,navien_units,sensor_type):    
     return {
         "gasInstantUsage": GenericSensorDescription(
@@ -87,6 +99,18 @@ def get_description(hass_units,navien_units,sensor_type):
             native_unit_of_measurement=UnitOfTemperature.CELSIUS if hass_units == "metric" else UnitOfTemperature.FAHRENHEIT,
             name="Hot Water Temp",
             convert_to = "None" if hass_units == navien_units else UnitOfTemperature.FAHRENHEIT if hass_units == "us_customary" else UnitOfTemperature.CELSIUS
+        ),
+        "errorCode": RawSensorDescription(
+            state_class = None,
+            native_unit_of_measurement = None,
+            name = "Error Code",
+            entity_category = EntityCategory.DIAGNOSTIC
+        ),
+        "subErrorCode": RawSensorDescription(
+            state_class = None,
+            native_unit_of_measurement = None,
+            name = "Sub Error Code",
+            entity_category = EntityCategory.DIAGNOSTIC
         )
     }.get(sensor_type,{})
 
@@ -104,7 +128,7 @@ async def async_setup_entry(
         hass_units = "us_customary" if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT else "metric"
         sensors.append(NavienAvgCalorieSensor(navilink, channel))
         for unit_info in channel.channel_status.get("unitInfo",{}).get("unitStatusList",[]):
-            for sensor_type in ["gasInstantUsage","accumulatedGasUsage","DHWFlowRate","currentInletTemp","currentOutletTemp"]:
+            for sensor_type in ["gasInstantUsage","accumulatedGasUsage","DHWFlowRate","currentInletTemp","currentOutletTemp","errorCode","subErrorCode"]:
                 sensors.append(NavienSensor(hass, navilink, channel, unit_info, sensor_type, get_description(hass_units,navien_units,sensor_type)))
     async_add_entities(sensors)
 
@@ -215,6 +239,19 @@ class NavienSensor(SensorEntity):
             manufacturer = "Navien",
             name = self.navilink.device_info.get("deviceInfo",{}).get("deviceName","unknown") + " CH" + str(self.channel.channel_number),
         )
+
+    @property
+    def entity_category(self):
+        """Return the entity category of this entity, if any."""
+        return getattr(self.sensor_description, "entity_category", None)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the human-readable description for the current error code, if any."""
+        if self.sensor_type != "errorCode":
+            return None
+        description = get_error_description(self.unit_info.get("errorCode", 0), self.unit_info.get("subErrorCode", 0))
+        return {"description": description} if description else None
 
     @property
     def name(self):


### PR DESCRIPTION
## Add errorCode / subErrorCode diagnostic sensors, decoded
The `channelStatus` MQTT payload already includes the `errorCode` & `subErrorCode` fields per unit (inside `unitInfo.unitStatusList`), but the integration currently drops them - `convert_channel_status` never surfaces them and `sensor.py` doesn't create entities.

## Changes
- Add 2 diagnostic sensors - `Error Code` & `Sub Error Code` that expose the raw values directly. Both currently read `0`/`0` under normal operation on my unit (NPE-240A2)
- Add a lookup table (`const.py`), sourced from the official Navien NPE Service Manual (v2.21, §5.1 "Error Code List"), so the `Error Code` sensor exposes a `description` attribute with the actual meaning (e.g. "Ignition failure") whenever the code is documented - not just the raw number.

## Scope
This lets users write HA automations that alert on unit faults with a real description, not just a code - which is what prompted this PR (had an ignition failure `E003-00` and I want HA to tell me what it means, not just that something was wrong).

## Testing
Tested by confirming the raw field names via a live payload capture, then verifying the new entities and description populate correctly after a restart.